### PR TITLE
fix file upload naming everything, well, file.

### DIFF
--- a/src/main/java/com/indico/storage/UploadFile.java
+++ b/src/main/java/com/indico/storage/UploadFile.java
@@ -53,7 +53,7 @@ public class UploadFile implements RestRequest<JSONArray> {
         MultipartBody.Builder multipartBody = new MultipartBody.Builder().setType(MultipartBody.FORM);
 
         for (File file : files) {
-            multipartBody.addFormDataPart(file.getName(), "file",
+            multipartBody.addFormDataPart(file.getName(), file.getName(),
                     RequestBody.create(MediaType.parse("application/octet-stream"), file));
         }
 


### PR DESCRIPTION
fixes the issue with everything coming from java being mysteriously named file.pdf (it's files all the way down)