### PR TITLE
[CAT-78] Help resolve some connection issues/crashing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ signing {
 
 group = "com.indico"
 archivesBaseName = "indico-client-java"
-version = "4.11.0"
+version = "4.0.10"
 
 uploadArchives {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ signing {
 
 group = "com.indico"
 archivesBaseName = "indico-client-java"
-version = "4.0.8"
+version = "4.11.0"
 
 uploadArchives {
     repositories {
@@ -94,6 +94,7 @@ dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter:5.5.2')
     testImplementation('org.mock-server:mockserver-netty:5.8.0')
     implementation('com.apollographql.apollo:apollo-runtime:1.2.2')
+    implementation('org.apache.logging.log4j:log4j-1.2-api:2.14.1')
     api('org.json:json:20190722')
     compileOnly("org.jetbrains:annotations:13.0")
     testCompileOnly("org.jetbrains:annotations:13.0")  

--- a/examples/SingleDocExtraction.java
+++ b/examples/SingleDocExtraction.java
@@ -32,6 +32,8 @@ public class SingleDocExtraction {
             String url = obj.getString("url");
             RetrieveBlob retrieveBlob = client.retrieveBlob();
             Blob blob = retrieveBlob.url(url).execute();
+            //call close on blob to dispose when done with object.
+            blob.close();
             System.out.println(blob.asString());
         } catch (Exception e) {
             e.printStackTrace();

--- a/examples/Submission.java
+++ b/examples/Submission.java
@@ -52,6 +52,8 @@ public class Submission {
             String url = obj.getString("url");
             RetrieveBlob retrieveBlob = client.retrieveBlob();
             Blob blob = retrieveBlob.url(url).execute();
+            //call close on blob to dispose when done with object.
+            blob.close();
             System.out.println(blob.asString());
             client.updateSubmission().submissionId(submissionId).retrieved(true).execute();
             

--- a/examples/Submission.java
+++ b/examples/Submission.java
@@ -40,7 +40,12 @@ public class Submission {
             Job job = client.submissionResult().submission(submissionId).execute();
             
             while (job.status() == JobStatus.PENDING) {
-                Thread.sleep(1000);
+                try {
+                    Thread.sleep(1000);
+                    Job job = client.submissionResult().submission(submissionId).execute();
+                }catch(CompletionException ex){
+                    this.indicoClient = new IndicoClient(config);
+                }
             }
 
             JSONObject obj = job.result();

--- a/examples/Workflow.java
+++ b/examples/Workflow.java
@@ -47,6 +47,8 @@ public class Workflow {
                 String url = obj.getString("url");
                 RetrieveBlob retrieveBlob = client.retrieveBlob();
                 Blob blob = retrieveBlob.url(url).execute();
+                //call close on blob to dispose when done with object.
+                blob.close();
                 System.out.println(blob.asString());
             }
         } catch (Exception e) {

--- a/examples/Workflow.java
+++ b/examples/Workflow.java
@@ -11,6 +11,9 @@ import java.util.ArrayList;
 import java.util.List;
 import org.json.JSONObject;
 
+/***
+ * Used for one-off jobs. Most use cases want to follow the pattern in Submission.java instead.
+ */
 public class Workflow {
 
     public static void main(String args[]) throws IOException {

--- a/src/main/java/com/indico/Async.java
+++ b/src/main/java/com/indico/Async.java
@@ -4,9 +4,6 @@ import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
 
-
-import java.net.SocketTimeoutException;
-import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -16,7 +13,6 @@ import com.apollographql.apollo.exception.ApolloParseException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 
 public class Async {
     static AtomicInteger counter = new AtomicInteger();

--- a/src/main/java/com/indico/Async.java
+++ b/src/main/java/com/indico/Async.java
@@ -5,98 +5,56 @@ import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import com.apollographql.apollo.exception.ApolloHttpException;
-import com.apollographql.apollo.exception.ApolloNetworkException;
-import com.apollographql.apollo.exception.ApolloParseException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class Async {
-    static AtomicInteger counter = new AtomicInteger();
     private static final Logger logger = LogManager.getLogger(Async.class);
 
     /**
-     * Synchronizes apollographql api calls with the help of dispatcher
-     * Retries up to 3 times by default on Network or Http Exception.
-     * @param <T>
-     * @param apolloCall instance of ApolloCall
-     * @return synchronous Response from query specified by apolloCall
-     */
-    public static <T> CompletableFuture<Response<T>> executeSync(ApolloCall<T> apolloCall, IndicoConfig config) {
-       return executeSync(apolloCall, config.maxRetries);
-    }
-
-    /**
-     * Executes with retry logic up to the specified number of retries.
+     * Executes a an apollo graphQL call.
      * Specify the maximum amount of retries.
      * @param apolloCall
-     * @param retries
      * @param <T>
      * @return
      */
-    public static <T> CompletableFuture<Response<T>> executeSync(ApolloCall<T> apolloCall, int retries) {
-        counter.set(0);
-        while(counter.get() < retries){
-            CompletableFuture<Response<T>> completableFuture = new CompletableFuture<>();
-            completableFuture.whenComplete((tResponse, throwable) -> {
+    public static <T> CompletableFuture<Response<T>> executeSync(ApolloCall<T> apolloCall) {
+        CompletableFuture<Response<T>> completableFuture = new CompletableFuture<>();
+        completableFuture.whenComplete((tResponse, throwable) -> {
             if (completableFuture.isCancelled()) {
 
                 completableFuture.cancel(true);
             }
         });
-            try{
-                apolloCall.enqueue(new ApolloCall.Callback<T>() {
+            apolloCall.enqueue(new ApolloCall.Callback<T>() {
 
 
-                    public void onResponse(Response<T> response) {
-                        completableFuture.complete(response);
+                public void onResponse(Response<T> response) {
+                    completableFuture.complete(response);
 
+
+                }
+
+                public void onFailure(ApolloException e) {
+                    logger.error("Failed to execute apollo call...");
+                    completableFuture.completeExceptionally(e);
+                }
+
+                public void onHttpError(ApolloHttpException e) {
+                    okhttp3.Response response = e.rawResponse();
+                    if (response != null) {
+                        response.close();
                     }
-
-                    public void onFailure(ApolloException e)
-                    {
-                        completableFuture.completeExceptionally(e);
-                    }
-
-
-                });}
-            catch(ApolloNetworkException | ApolloParseException e){
-                //parse exception can happen when there is a protocol_error
-                //thrown by OKHttpClient
-                if(counter.get() < retries){
-                    logger.debug("Retrying call due to " + e.getMessage());
-                    completableFuture.cancel(true);
-                    counter.incrementAndGet();
-
+                    completableFuture.completeExceptionally(e);
                 }
-                else{
-                    throw new RuntimeException("Max number of retries met, giving up", e);
-                }
-            }catch(ApolloHttpException e){
-                // could store this in an array but let's try this for now.
-                logger.trace("Retrying call" + apolloCall.getClass() + "due to " + e.code());
-                if(counter.get() < retries && e.code() == 504 || e.code() == 503 || e.code() == 502){
 
-                    completableFuture.cancel(true);
-                    counter.incrementAndGet();
-                }
-                else{
-                    logger.trace("Failed call" + apolloCall.getClass() + "due to " + e.code());
-                    throw new RuntimeException("Max number of retries met, giving up", e);
-                }
-            }
-            catch(Exception ex){
-                logger.debug("Retrying call" + apolloCall.getClass() + "due to " + ex.getMessage());
-                completableFuture.completeExceptionally(ex);
-            }
-         return completableFuture;
-        }
-        return new CompletableFuture<>();
+            });
+        return completableFuture;
+
+
     }
-
-
 
 }

--- a/src/main/java/com/indico/AuthorizationInterceptor.java
+++ b/src/main/java/com/indico/AuthorizationInterceptor.java
@@ -49,6 +49,7 @@ public class AuthorizationInterceptor implements Interceptor{
             String responseBody = refreshResponse.body().string();
             JSONObject json = new JSONObject(responseBody);
             authToken = (String) json.get("auth_token");
+            refreshResponse.close();
         } else {
             throw new RuntimeException("Failed to refresh authentication state");
         }

--- a/src/main/java/com/indico/IndicoClient.java
+++ b/src/main/java/com/indico/IndicoClient.java
@@ -1,7 +1,6 @@
 package com.indico;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -9,7 +8,6 @@ import com.apollographql.apollo.ApolloClient;
 import com.indico.mutation.*;
 import com.indico.query.*;
 import com.indico.storage.UploadFile;
-import com.sun.net.httpserver.Authenticator;
 import okhttp3.OkHttpClient;
 
 import com.indico.jobs.JobQuery;
@@ -24,8 +22,8 @@ import com.indico.request.GraphQLRequest;
 public class IndicoClient implements AutoCloseable {
 
     public final IndicoConfig config;
-    public OkHttpClient okHttpClient;
-    public ApolloClient apolloClient;
+    public final OkHttpClient okHttpClient;
+    public  final ApolloClient apolloClient;
     private final ThreadPoolExecutor dispatcher;
 
     public IndicoClient(IndicoConfig config) {
@@ -187,7 +185,7 @@ public class IndicoClient implements AutoCloseable {
     }
 
     /**
-     * Closes the connnection to graphql server since the ThreadPool remains
+     * Closes the connection to graphql server since the ThreadPool remains
      * active for several seconds before closing due to multiple asynchronous
      * queries and prevents JVM from closing for 60 seconds.
      *
@@ -196,33 +194,6 @@ public class IndicoClient implements AutoCloseable {
     public void close() {
         this.dispatcher.shutdown();
         this.okHttpClient.dispatcher().executorService().shutdown();
-    }
-
-    public void reset(){
-        String serverURL = config.protocol + "://" + config.host;
-
-        AuthorizationInterceptor interceptor = new AuthorizationInterceptor(serverURL, config.apiToken, config);
-        RetryInterceptor retryInterceptor = new RetryInterceptor(config);
-        try {
-            interceptor.refreshAuthState();
-        } catch (IOException exception) {
-            throw new RuntimeException(exception);
-        }
-
-        this.okHttpClient = new OkHttpClient.Builder()
-                .authenticator(new TokenAuthenticator(interceptor))
-                .addInterceptor(interceptor)
-                .addInterceptor(retryInterceptor)
-                .readTimeout(config.connectionReadTimeout, TimeUnit.SECONDS)
-                .writeTimeout(config.connectionWriteTimeout, TimeUnit.SECONDS)
-                .connectTimeout(config.connectTimeout, TimeUnit.SECONDS)
-                .build();
-
-        this.apolloClient = ApolloClient.builder()
-                .serverUrl(serverURL + "/graph/api/graphql")
-                .okHttpClient(this.okHttpClient)
-                .dispatcher(this.dispatcher)
-                .build();
     }
 
     /**

--- a/src/main/java/com/indico/RetryInterceptor.java
+++ b/src/main/java/com/indico/RetryInterceptor.java
@@ -20,10 +20,10 @@ public class RetryInterceptor  implements Interceptor {
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();
 
-        Response response = null;
-        boolean success = false;
+        Response response = chain.proceed(request);
+        boolean success = response.isSuccessful();
         int tryCount = 0;
-        while ((response == null || !success) && tryCount < indicoConfig.maxRetries) {
+        while (!success && tryCount < indicoConfig.maxRetries) {
             tryCount++;
             try {
                 response = chain.proceed(request);
@@ -42,7 +42,7 @@ public class RetryInterceptor  implements Interceptor {
                 }
             }
         }
-        logger.trace("Completed in " + tryCount + " attempts. Successfully? " + success);
+        logger.trace("Completed in " + tryCount + " extra attempts. Successfully? " + success);
         return response;
     }
 }

--- a/src/main/java/com/indico/TokenAuthenticator.java
+++ b/src/main/java/com/indico/TokenAuthenticator.java
@@ -9,9 +9,13 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.Route;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 
 class TokenAuthenticator implements Authenticator {
+
+    private final Logger logger = LogManager.getLogger(TokenAuthenticator.class);
 
     final AuthorizationInterceptor interceptor;
     /**
@@ -34,6 +38,7 @@ class TokenAuthenticator implements Authenticator {
      */
     @Override
     public Request authenticate(Route route, Response response) throws IOException {
+        logger.trace("Refreshing authentication for " + route.toString());
         interceptor.refreshAuthState();
         return response.request().newBuilder().header("Authorization", interceptor.authHeader()).build();
     }

--- a/src/main/java/com/indico/jobs/Job.java
+++ b/src/main/java/com/indico/jobs/Job.java
@@ -2,6 +2,9 @@ package com.indico.jobs;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloClient;
 import com.apollographql.apollo.api.Response;
@@ -29,13 +32,17 @@ public class Job {
      * @return JobStatus
      */
     public JobStatus status() {
+        try{
         ApolloCall<JobStatusGraphQLQuery.Data> apolloCall = this.indicoClient.apolloClient.query(JobStatusGraphQLQuery.builder()
                 .id(this.id)
                 .build());
-        Response<JobStatusGraphQLQuery.Data> response = (Response<JobStatusGraphQLQuery.Data>) Async.executeSync(apolloCall, this.indicoClient.config).join();
+        Response<JobStatusGraphQLQuery.Data> response = Async.executeSync(apolloCall).get();
         JobStatusGraphQLQuery.Data data = response.data();
         JobStatus status = data.job().status();
         return status;
+        }catch (CompletionException | ExecutionException | InterruptedException ex){
+            throw new RuntimeException("Call for the job status failed", ex);
+        }
     }
 
     public String resultAsString() {
@@ -69,10 +76,11 @@ public class Job {
      * @return Result String
      */
     private String fetchResult() {
+        try{
         ApolloCall<JobResultGraphQLQuery.Data> apolloCall = this.indicoClient.apolloClient.query(JobResultGraphQLQuery.builder()
                 .id(this.id)
                 .build());
-        Response<JobResultGraphQLQuery.Data> response = (Response<JobResultGraphQLQuery.Data>) Async.executeSync(apolloCall, this.indicoClient.config).join();
+        Response<JobResultGraphQLQuery.Data> response = Async.executeSync(apolloCall).get();
         JobResultGraphQLQuery.Data data = response.data();
 
         JobResultGraphQLQuery.Job job = data.job();
@@ -88,6 +96,9 @@ public class Job {
 
         String out = result.toString();
         return out;
+        }catch (CompletionException | ExecutionException | InterruptedException ex){
+            throw new RuntimeException("Call for the job result failed", ex);
+        }
     }
 
     /**

--- a/src/main/java/com/indico/mutation/GenerateSubmissionResult.java
+++ b/src/main/java/com/indico/mutation/GenerateSubmissionResult.java
@@ -43,7 +43,6 @@ public class GenerateSubmissionResult implements Mutation<Job> {
         String jobId = submissionResults.jobId();
         return new Job(this.client, jobId);  }
         catch (CompletionException | ExecutionException | InterruptedException ex){
-            this.client.reset();
             throw new RuntimeException("Call to generate the submission result failed", ex);
         }
     }

--- a/src/main/java/com/indico/mutation/ModelGroupLoad.java
+++ b/src/main/java/com/indico/mutation/ModelGroupLoad.java
@@ -10,6 +10,9 @@ import com.indico.Mutation;
 import com.indico.LoadModelGraphQLMutation;
 import com.indico.entity.ModelGroup;
 
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
 public class ModelGroupLoad implements Mutation<String> {
 
     private int modelId;
@@ -50,11 +53,16 @@ public class ModelGroupLoad implements Mutation<String> {
      */
     @Override
     public String execute() {
-        ApolloCall<LoadModelGraphQLMutation.Data> apolloCall = this.indicoClient.apolloClient.mutate(LoadModelGraphQLMutation.builder()
-                .model_id(modelId)
-                .build());
-        Response<LoadModelGraphQLMutation.Data> response = (Response<LoadModelGraphQLMutation.Data>) Async.executeSync(apolloCall, this.indicoClient.config).join();
-        String status = response.data().modelLoad().status();
-        return status;
+        try {
+            ApolloCall<LoadModelGraphQLMutation.Data> apolloCall = this.indicoClient.apolloClient.mutate(LoadModelGraphQLMutation.builder()
+                    .model_id(modelId)
+                    .build());
+            Response<LoadModelGraphQLMutation.Data> response = Async.executeSync(apolloCall).get();
+            String status = response.data().modelLoad().status();
+            return status;
+
+        } catch (CompletionException | ExecutionException | InterruptedException ex) {
+            throw new RuntimeException("Call to load model group failed", ex);
+        }
     }
 }

--- a/src/main/java/com/indico/mutation/SubmissionResult.java
+++ b/src/main/java/com/indico/mutation/SubmissionResult.java
@@ -67,10 +67,10 @@ public class SubmissionResult implements Mutation<Job> {
         GenerateSubmissionResult generateSubmissionResult = new GenerateSubmissionResult(this.client)
                 .submission(submission);
         Job job = generateSubmissionResult.execute();
-        return job;}
+        return job;
+        }
         catch (CompletionException ex){
                 throw new RuntimeException("Call to get submission result failed", ex);
-
             }
     }
 

--- a/src/main/java/com/indico/mutation/SubmissionResult.java
+++ b/src/main/java/com/indico/mutation/SubmissionResult.java
@@ -69,7 +69,6 @@ public class SubmissionResult implements Mutation<Job> {
         Job job = generateSubmissionResult.execute();
         return job;}
         catch (CompletionException ex){
-                this.client.reset();
                 throw new RuntimeException("Call to get submission result failed", ex);
 
             }

--- a/src/main/java/com/indico/query/GetSubmission.java
+++ b/src/main/java/com/indico/query/GetSubmission.java
@@ -55,7 +55,6 @@ public class GetSubmission implements Query<Submission> {
                 .retrieved(submission.retrieved())
                 .build();
         }catch (CompletionException | ExecutionException | InterruptedException ex){
-            this.client.reset();
             throw new RuntimeException("Call to get the submission failed", ex);
         }
     }

--- a/src/main/java/com/indico/query/GetSubmission.java
+++ b/src/main/java/com/indico/query/GetSubmission.java
@@ -8,6 +8,9 @@ import com.indico.IndicoClient;
 import com.indico.Query;
 import com.indico.entity.Submission;
 
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
 public class GetSubmission implements Query<Submission> {
     private final IndicoClient client;
     private int submissionId;
@@ -34,11 +37,12 @@ public class GetSubmission implements Query<Submission> {
      */
     @Override
     public Submission query() {
+        try{
         ApolloCall<GetSubmissionGraphQLQuery.Data> apolloCall = this.client.apolloClient.query(GetSubmissionGraphQLQuery.builder()
                 .submissionId(this.submissionId)
                 .build());
 
-        Response<GetSubmissionGraphQLQuery.Data> response = (Response<GetSubmissionGraphQLQuery.Data>) Async.executeSync(apolloCall, maxRetries).join();
+        Response<GetSubmissionGraphQLQuery.Data> response = Async.executeSync(apolloCall).get();
         GetSubmissionGraphQLQuery.Submission submission = response.data().submission();
         return new Submission.Builder()
                 .id(submission.id())
@@ -50,6 +54,10 @@ public class GetSubmission implements Query<Submission> {
                 .resultFile(submission.resultFile())
                 .retrieved(submission.retrieved())
                 .build();
+        }catch (CompletionException | ExecutionException | InterruptedException ex){
+            this.client.reset();
+            throw new RuntimeException("Call to get the submission failed", ex);
+        }
     }
 
     /**

--- a/src/main/java/com/indico/request/GraphQLRequest.java
+++ b/src/main/java/com/indico/request/GraphQLRequest.java
@@ -68,7 +68,7 @@ public class GraphQLRequest implements RestRequest<JSONObject> {
             throw new ApolloException(errors.toString());
         }
         JSONObject data = response.getJSONObject("data");
-
+        result.close();
         return data;
     }
 }

--- a/src/main/java/com/indico/storage/Blob.java
+++ b/src/main/java/com/indico/storage/Blob.java
@@ -7,7 +7,7 @@ import org.json.JSONObject;
 
 import java.io.*;
 
-public class Blob {
+public class Blob implements AutoCloseable {
 
     InputStream data = null;
     private Response response = null;
@@ -17,6 +17,7 @@ public class Blob {
     }
 
     public Blob(Response response) {
+        this.response = response;
         this.data = response.body().byteStream();
     }
 
@@ -33,9 +34,10 @@ public class Blob {
      * Returns Blob as String
      *
      * @return String
-     * @throws IOException
+     * @throws RuntimeException
      */
-    public String asString() throws IOException {
+    public String asString(){
+        try{
         Reader reader = new InputStreamReader(this.data);
         Writer writer = new StringWriter();
 
@@ -47,6 +49,13 @@ public class Blob {
             response.close();
         }
         return writer.toString();
+        } catch(IOException ex){
+            if(response != null){
+                response.close();
+            }
+            throw new RuntimeException(ex);
+        }
+
     }
 
     /**
@@ -69,5 +78,10 @@ public class Blob {
     public JSONArray asJSONArray() throws IOException {
         String jsonString = this.asString();
         return new JSON(jsonString).asJSONArray();
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.response.close();
     }
 }

--- a/src/main/java/com/indico/storage/Blob.java
+++ b/src/main/java/com/indico/storage/Blob.java
@@ -10,6 +10,7 @@ import java.io.*;
 public class Blob {
 
     InputStream data = null;
+    private Response response = null;
 
     public Blob(InputStream data) {
         this.data = data;
@@ -41,6 +42,9 @@ public class Blob {
         char[] buffer = new char[10240];
         for (int length = 0; (length = reader.read(buffer)) > 0;) {
             writer.write(buffer, 0, length);
+        }
+        if(response != null){
+            response.close();
         }
         return writer.toString();
     }

--- a/src/main/java/com/indico/storage/RetrieveBlob.java
+++ b/src/main/java/com/indico/storage/RetrieveBlob.java
@@ -87,7 +87,7 @@ public class RetrieveBlob {
      * @throws IOException
      */
     public Blob execute() throws IOException {
-        return new Blob(this.getInputStream());
+        return new Blob(this.retrieveBlob());
     }
 
 }

--- a/src/main/java/com/indico/storage/RetrieveBlob.java
+++ b/src/main/java/com/indico/storage/RetrieveBlob.java
@@ -14,10 +14,11 @@ import okhttp3.Response;
  * Retrieve a blob After setting the parameters to retrieve the blob use
  * getInputStream to retrieve the content of the blob
  */
-public class RetrieveBlob {
+public class RetrieveBlob implements AutoCloseable {
 
     private String url;
     private IndicoClient client;
+    private Response response;
 
     public RetrieveBlob(IndicoClient client) {
         this.client = client;
@@ -87,7 +88,13 @@ public class RetrieveBlob {
      * @throws IOException
      */
     public Blob execute() throws IOException {
-        return new Blob(this.retrieveBlob());
+        Response response = this.retrieveBlob();
+        this.response = response;
+        return new Blob(response);
+    }
+
+    public void close(){
+        this.response.close();
     }
 
 }

--- a/src/main/java/com/indico/storage/UploadFile.java
+++ b/src/main/java/com/indico/storage/UploadFile.java
@@ -66,6 +66,7 @@ public class UploadFile implements RestRequest<JSONArray> {
         Response result = client.okHttpClient.newCall(request).execute();
         String body = result.body().string();
         JSONArray fileMeta = new JSON(body).asJSONArray();
+        result.close();
         return (JSONArray) fileMeta;
     }
 }

--- a/update-schema.sh
+++ b/update-schema.sh
@@ -1,0 +1,12 @@
+#fetch and update the schema
+#snap install jq && snap install node
+REFRESH_TOKEN=$(<~/indico_api_token.txt)
+PROJ=./
+
+TOKEN=$(curl --location --request POST 'https://dev.indico.io/auth/users/refresh_token' \
+--header "Authorization: Bearer $REFRESH_TOKEN" \
+ | jq .auth_token \
+ | tr -d '"')
+
+
+npx apollo schema:download --endpoint=https://dev.indico.io/graph/api/graphql schema.json --header="Authorization: Bearer $TOKEN"


### PR DESCRIPTION
Close responses more appropriately. Also updating the example for Submissions. When a `CompletionException` is hit, the underlying clients can end up in a bad state so, for now, it's better to refresh the client when that particular exception is hit.