### PR TITLE
[CAT-525] ADD post_processing submission status

### DIFF
--- a/src/main/java/com/indico/type/SubmissionStatus.kt
+++ b/src/main/java/com/indico/type/SubmissionStatus.kt
@@ -5,6 +5,7 @@ enum class SubmissionStatus {
     PENDING_REVIEW,
     PENDING_ADMIN_REVIEW,
     PENDING_AUTO_REVIEW,
+    POST_PROCESSING,
     COMPLETE,
     FAILED,
 }

--- a/src/main/resources/schema.graphql
+++ b/src/main/resources/schema.graphql
@@ -2459,6 +2459,7 @@ enum SubmissionStatus {
   PENDING_AUTO_REVIEW
   PENDING_REVIEW
   PROCESSING
+  POST_PROCESSING
 }
 
 "An enumeration."


### PR DESCRIPTION
Pretty sure these are the only changes we need to make-- unlike in the C# and Python sdks, I don't think the Java SDK has a `WaitForSubmission` function that uses SubmissionStatus.