### PR TITLE
[CAT-816] Format SDK docs

### DIFF
--- a/docs.Dockerfile
+++ b/docs.Dockerfile
@@ -1,5 +1,0 @@
-FROM gradle:jdk8
-
-WORKDIR /src
-COPY . /src/
-RUN ./gradlew dokkaGfm

--- a/readme_docs/Dockerfile
+++ b/readme_docs/Dockerfile
@@ -1,5 +1,5 @@
 FROM gradle:jdk8
 
 WORKDIR /indico-client-java
-COPY .. /indico-client-java
+COPY . /indico-client-java
 CMD ["sleep", "infinity"]

--- a/readme_docs/Dockerfile
+++ b/readme_docs/Dockerfile
@@ -1,0 +1,5 @@
+FROM gradle:jdk8
+
+WORKDIR /indico-client-java
+COPY .. /indico-client-java
+CMD ["sleep", "infinity"]

--- a/readme_docs/Dockerfile
+++ b/readme_docs/Dockerfile
@@ -2,4 +2,5 @@ FROM gradle:jdk8
 
 WORKDIR /indico-client-java
 COPY . /indico-client-java
+RUN apt-get update && apt-get install jq -y
 CMD ["sleep", "infinity"]

--- a/readme_docs/build_docs.sh
+++ b/readme_docs/build_docs.sh
@@ -6,7 +6,18 @@ rm package-list
 
 for filename in $(find . -type f); do
   if [ $(basename $filename) = "index.md" ]; then
-    newName=$(dirname $filename | sed -r 's|\-(\w)\-|\1|g; s|/-|/|g; s|-(\w)_|\1-|g; s|_|-|g; s|\./||; s|\.|-|g; s|/|-|2g; s|(.+)\-(\w)$|\1\2|g')
+    # In file names, Dokka separates lower case words with hyphens. It also separates capital letters with hyphens.
+    # Since Readme doesn't support capital letters in doc slugs, make all letters lowercase and reserve the hyphen to indicate space between words
+    # 1. if a word character has hyphens on each side, remove the hyphens.
+    # 2. if a word character occurs between a hyphen and the end of a line, remove the hyphen
+    # 3. remove any hyphens that occur after slashes
+    # 4. remove last hyphen that occurs before a word break (word breaks are indicated by _ in enums)
+    # 5. replace _ with - to represent word breaks-- this mostly applied to enums like PENDING_REVIEW
+    # 6. remove the leading ./ that occurs at the beginning of each file so it doesn't get turned into a dash in step 6
+    # 7. since readme ignores periods in doc slugs, make any periods into - to make the slugs more readable
+    # 8. since readme only supports two levels of docs, transform any / after the first occurrence into a -.
+    # This ensures the classes with the same names (like the workflow Builder and submission Builder) will have unique slugs
+    newName=$(dirname $filename | sed -r 's|\-(\w)\-|\1|g; s|(.+)\-(\w)$|\1\2|g; s|/-|/|g; s|-(\w)_|\1-|g; s|_|-|g; s|\./||; s|\.|-|g; s|/|-|2g')
     newName="./$newName.md"
     mkdir -p $(dirname $newName)
     mv $filename $newName

--- a/readme_docs/build_docs.sh
+++ b/readme_docs/build_docs.sh
@@ -1,5 +1,5 @@
-#./gradlew dokkaGfm
-#mv build/dokka/gfm .
+./gradlew dokkaGfm
+mv build/dokka/gfm .
 
 cd gfm/indico-client-java
 rm package-list
@@ -9,17 +9,13 @@ rm package-list
 for filename in $(find . -type f); do
   if [ $(basename $filename) = "index.md" ]; then
     newName=$(dirname $filename | sed -r 's|\-(\w)\-|\1|g; s|/-|/|g; s|-(\w)_|\1-|g; s|_|-|g; s|\./||; s|\.|-|g; s|/|-|2g; s|(.+)\-(\w)$|\1\2|g')
-    newDir=$(dirname newName)
-    echo $filename
-    echo $newName
-    echo $newDir
-    mkdir -p "./$newDir"
-    mv $filename "./$newName.md"
+    newName="./$newName.md"
+    mkdir -p $(dirname $newName)
+    mv $filename $newName
   else
     rm $filename
   fi
 done
 
-#mv ../index.md ./index.md
-#
-#find . -type d -empty -delete
+mv ../index.md ./index.md
+find . -type d -empty -delete

--- a/readme_docs/build_docs.sh
+++ b/readme_docs/build_docs.sh
@@ -1,5 +1,5 @@
-./gradlew dokkaGfm
-mv build/dokka/gfm .
+#./gradlew dokkaGfm
+#mv build/dokka/gfm .
 
 cd gfm/indico-client-java
 rm package-list
@@ -7,19 +7,19 @@ rm package-list
 # make all relative links absolute
 
 for filename in $(find . -type f); do
-  readable_filename=$(echo $filename | sed -r 's|j\-s\-o\-n|json|g; s|\-(\w)\-|\1|g; s|\-(\w[_/])|\1|g; s|\-(\w)$|\1|g; s|_|\-|g; s|/\-|/|g')
-  dirname=$(echo $readable_filename | sed -r 's|(.+com\.indico[^/]*)/.+|\1|; s|\./||; s|\.|-|g')
-  dirname="./$dirname"
   if [ $(basename $filename) = "index.md" ]; then
-    newlocation="$dirname.md"
+    newName=$(dirname $filename | sed -r 's|\-(\w)\-|\1|g; s|/-|/|g; s|-(\w)_|\1-|g; s|_|-|g; s|\./||; s|\.|-|g; s|/|-|2g; s|(.+)\-(\w)$|\1\2|g')
+    newDir=$(dirname newName)
+    echo $filename
+    echo $newName
+    echo $newDir
+    mkdir -p "./$newDir"
+    mv $filename "./$newName.md"
   else
-    mkdir -p $dirname
-    newfilename=$(echo $readable_filename | sed -r 's|(.+com\.indico[^/]*/)(.+)|\2|; s|/|\-|g')
-    newlocation="$dirname/$newfilename"
+    rm $filename
   fi
-  mv $filename $newlocation
 done
 
-mv ../index.md ./index.md
-
-find . -type d -empty -delete
+#mv ../index.md ./index.md
+#
+#find . -type d -empty -delete

--- a/readme_docs/build_docs.sh
+++ b/readme_docs/build_docs.sh
@@ -1,0 +1,24 @@
+./gradlew dokkaGfm
+mv build/dokka/gfm .
+
+cd gfm/indico-client-java
+rm package-list
+
+# make all relative links absolute
+
+for filename in $(find . -type f); do
+  readable_filename=$(echo $filename | sed -r 's|j\-s\-o\-n|json|g; s|\-(\w)\-|\1|g; s|\-(\w[_/])|\1|g; s|\-(\w)$|\1|g; s|_|\-|g; s|/\-|/|g')
+  dirname=$(echo $readable_filename | sed -r 's|(.+com\.indico[^/]*)/.+|\1|')
+  if [ $(basename $filename) = "index.md" ]; then
+    newlocation="$dirname.md"
+  else
+    mkdir -p dirname
+    newfilename=$(echo $readable_filename | sed -r 's|(.+com\.indico[^/]*/)(.+)|\2|; s|/|\-|g')
+    newlocation="$dirname/$newfilename"
+  fi
+  mv $filename $newlocation
+done
+
+mv ../index.md ./index.md
+
+find . -type d -empty -delete

--- a/readme_docs/build_docs.sh
+++ b/readme_docs/build_docs.sh
@@ -4,8 +4,6 @@ mv build/dokka/gfm .
 cd gfm/indico-client-java
 rm package-list
 
-# make all relative links absolute
-
 for filename in $(find . -type f); do
   if [ $(basename $filename) = "index.md" ]; then
     newName=$(dirname $filename | sed -r 's|\-(\w)\-|\1|g; s|/-|/|g; s|-(\w)_|\1-|g; s|_|-|g; s|\./||; s|\.|-|g; s|/|-|2g; s|(.+)\-(\w)$|\1\2|g')
@@ -18,4 +16,6 @@ for filename in $(find . -type f); do
 done
 
 mv ../index.md ./index.md
+# clean up links
+find . -type f -name '*.md' -print0 | xargs -0 sed -i -r "s|\[([^]]*)\]\([^)]+\.md[^\)]*\)|\1|g"
 find . -type d -empty -delete

--- a/readme_docs/build_docs.sh
+++ b/readme_docs/build_docs.sh
@@ -8,11 +8,12 @@ rm package-list
 
 for filename in $(find . -type f); do
   readable_filename=$(echo $filename | sed -r 's|j\-s\-o\-n|json|g; s|\-(\w)\-|\1|g; s|\-(\w[_/])|\1|g; s|\-(\w)$|\1|g; s|_|\-|g; s|/\-|/|g')
-  dirname=$(echo $readable_filename | sed -r 's|(.+com\.indico[^/]*)/.+|\1|')
+  dirname=$(echo $readable_filename | sed -r 's|(.+com\.indico[^/]*)/.+|\1|; s|\./||; s|\.|-|g')
+  dirname="./$dirname"
   if [ $(basename $filename) = "index.md" ]; then
     newlocation="$dirname.md"
   else
-    mkdir -p dirname
+    mkdir -p $dirname
     newfilename=$(echo $readable_filename | sed -r 's|(.+com\.indico[^/]*/)(.+)|\2|; s|/|\-|g')
     newlocation="$dirname/$newfilename"
   fi

--- a/readme_docs/harness_docs.yaml
+++ b/readme_docs/harness_docs.yaml
@@ -49,7 +49,7 @@ pipeline:
                       chmod +x ./readme_docs/build_docs.sh
                       ./readme_docs/build_docs.sh
 
-                      cp -r ./gfm $DOCS_PATH
+                      cp -r ./gfm/indico-client-java $DOCS_PATH
                       git clone https://user:$GITHUB_TOKEN@github.com/IndicoDataSolutions/indico-readme.git
                       cd indico-readme
                       git checkout main
@@ -81,7 +81,7 @@ pipeline:
                         resources:
                           limits:
                             cpu: "0.5"
-                            memory: 500Mi
+                            memory: 900Mi
                         annotations: {}
                         labels: {}
                         containerSecurityContext:

--- a/readme_docs/harness_docs.yaml
+++ b/readme_docs/harness_docs.yaml
@@ -1,0 +1,112 @@
+pipeline:
+  projectIdentifier: IPA_Release
+  orgIdentifier: default
+  tags: {}
+  stages:
+    - stage:
+        name: Build Docs Container
+        identifier: Build_Docs_Container
+        description: ""
+        type: CI
+        spec:
+          cloneCodebase: true
+          execution:
+            steps:
+              - step:
+                  type: BuildAndPushDockerRegistry
+                  name: BuildAndPushDockerRegistry_1
+                  identifier: BuildAndPushDockerRegistry_1
+                  spec:
+                    connectorRef: account.harbor
+                    repo: harbor.devops.indico.io/indico/indico-client-java
+                    tags:
+                      - <+codebase.commitSha>
+                    dockerfile: ./readme_docs/Dockerfile
+          platform:
+            os: Linux
+            arch: Amd64
+          runtime:
+            type: Cloud
+            spec: {}
+    - stage:
+        name: Build Java Docs
+        identifier: Build_Java_Docs
+        description: ""
+        type: Custom
+        spec:
+          execution:
+            steps:
+              - step:
+                  type: Container
+                  name: PR To Readme
+                  identifier: PR_To_Readme
+                  spec:
+                    connectorRef: account.harbor
+                    image: harbor.devops.indico.io/indico/indico-client-java:<+codebase.commitSha>
+                    command: |
+                      cd /indico-client-java
+
+                      chmod +x ./readme_docs/build_docs.sh
+                      ./readme_docs/build_docs.sh
+
+                      cp -r ./gfm $DOCS_PATH
+                      git clone https://user:$GITHUB_TOKEN@github.com/IndicoDataSolutions/indico-readme.git
+                      cd indico-readme
+                      git checkout main
+                      git config --global user.email "engineering@indico.io"
+                      git config --global user.name "cat-automation"
+                      git checkout -b docs-version-$TAG
+
+                      mkdir -p markdown
+                      cp -r $DOCS_PATH ./markdown/$LANGUAGE
+                      bash add_frontmatter_yaml.sh
+
+                      git add ./markdown/$LANGUAGE
+                      git commit -m "a set of doc changes"
+
+                      git push --set-upstream origin docs-version-$TAG
+                      curl -L \
+                        -X POST \
+                        -H "Accept: application/vnd.github+json" \
+                        -H "Authorization: Bearer $GITHUB_TOKEN" \
+                        -H "X-GitHub-Api-Version: 2022-11-28" \
+                        https://api.github.com/repos/IndicoDataSolutions/indico-readme/pulls \
+                        -d '{"title":"Amazing new feature","body":"Please pull these awesome changes in!","head":"docs-version-'"$TAG"'","base":"main"}'
+                    shell: Bash
+                    infrastructure:
+                      type: KubernetesDirect
+                      spec:
+                        connectorRef: account.Dev_Cluster
+                        namespace: default
+                        resources:
+                          limits:
+                            cpu: "0.5"
+                            memory: 500Mi
+                        annotations: {}
+                        labels: {}
+                        containerSecurityContext:
+                          capabilities:
+                            drop: []
+                            add: []
+                        nodeSelector: {}
+                    reports:
+                      type: JUnit
+                      spec:
+                        paths: []
+                    outputVariables: []
+                    envVariables:
+                      GITHUB_TOKEN: <+secrets.getValue("account.indicomachineuser_github_token")>
+                      TAG: <+codebase.commitSha>
+                      LANGUAGE: java
+                      README_API_KEY: <+secrets.getValue("meghanhickeyreadmepat")>
+                      DOCS_PATH: /harness/java
+                  timeout: 10m
+        tags: {}
+  properties:
+    ci:
+      codebase:
+        connectorRef: account.Indico
+        repoName: indico-client-java
+        build: <+input>
+  identifier: Generate_Java_Docs
+  name: Generate Java Docs


### PR DESCRIPTION
- Rearrange doc files so there's only two levels of nesting (which is the max number of levels readme supports)
- Only save index.md files
- Remove links to other files in documentation, but preserve links to kotlin docs
    - I tried to reformat or add back in the internal links, but because the links in the generated java docs are all relative (lots of `../../<file>.md`) I wasn't able to find a solution in the allotted timeframe  